### PR TITLE
Disable cluster alerting, no notifiers configured

### DIFF
--- a/playbooks/roles/ucluster/templates/cluster.csi.yml.j2
+++ b/playbooks/roles/ucluster/templates/cluster.csi.yml.j2
@@ -3,7 +3,7 @@ answers: null
 azureKubernetesServiceConfig: null
 description: mycluster
 dockerRootDir: /var/lib/docker
-enableClusterAlerting: true
+enableClusterAlerting: false
 enableClusterMonitoring: true
 enableNetworkPolicy: false
 googleKubernetesEngineConfig: null

--- a/playbooks/roles/ucluster/templates/cluster.yml.j2
+++ b/playbooks/roles/ucluster/templates/cluster.yml.j2
@@ -3,7 +3,7 @@ answers: null
 azureKubernetesServiceConfig: null
 description: mycluster
 dockerRootDir: /var/lib/docker
-enableClusterAlerting: true
+enableClusterAlerting: false
 enableClusterMonitoring: true
 enableNetworkPolicy: false
 googleKubernetesEngineConfig: null


### PR DESCRIPTION
Cluster alerting was enabled in the templates and this was resulting in the following errors showing up in the Events for the User Cluster:

- Warning  FailedMount       7m16s (x2 over 9m33s)  kubelet, dolker-wrk1  Unable to attach or mount volumes: unmounted volumes=[operator-init-monitoring-operator-token-cdg5k], unattached volumes=[operator-init-monitoring-operator-token-cdg5k data-crds]: timed out waiting for the condition
-   Warning  FailedMount       111s (x15 over 16m)    kubelet, dolker-wrk1  MountVolume.SetUp failed for volume "operator-init-monitoring-operator-token-cdg5k" : secret "operator-init-monitoring-operator-token-cdg5k" not found
-   Warning  FailedMount       30s (x5 over 14m)      kubelet, dolker-wrk1  Unable to attach or mount volumes: unmounted volumes=[operator-init-monitoring-operator-token-cdg5k], unattached volumes=[data-crds operator-init-monitoring-operator-token-cdg5k]: timed out waiting for the condition

Looking at the rancher documentation, before alerts can be enabled for a cluster you have to configure an alert notifier. Rancher supports the following notifiers at this time:

- Slack: Send alert notifications to your Slack channels.
- Email: Choose email recipients for alert notifications.
- PagerDuty: Route notifications to staff by phone, SMS, or personal email.
- WebHooks: Update a webpage with alert notifications.
- WeChat: Send alert notifications to your Enterprise WeChat contacts.

We are not configuring any of these notifiers, which means alerting won't work.  We've never done any integration in prior solutions with any of these notifiers and to my knowledge alerting is not a stated requirement for this solution.  

I am therefore updating both the CSI and non-CSI templates to disable cluster alerting, which eliminates the errors in the event log.  We can revisit enabling cluster alerting when/if it becomes a requirement and we are told which notifiers we must support.