### PR TITLE
Packer

### DIFF
--- a/playbooks/provision.yml
+++ b/playbooks/provision.yml
@@ -21,6 +21,7 @@
 #######################################################################
 - name: Generate vSphere Template
   hosts: template
+  force_handlers: true
   gather_facts: false
   roles:
   - role: template

--- a/playbooks/roles/template/handlers/main.yml
+++ b/playbooks/roles/template/handlers/main.yml
@@ -14,4 +14,9 @@
 # limitations under the License.
 ### 
 ---
-# handlers file for template
+- name: Delete Packer Variables
+  delegate_to: localhost
+  file:
+    path: "{{ packer_variables.path }}"
+    state: absent
+  when: packer_variables.path is defined

--- a/playbooks/roles/template/tasks/packer.yml
+++ b/playbooks/roles/template/tasks/packer.yml
@@ -37,8 +37,8 @@
 
 - name: Copy post install shell
   delegate_to: localhost
-  copy:
-     src: "{{ packer_os_flavor }}-post-provisioner.sh"
+  template:
+     src: "{{ packer_os_flavor }}-post-provisioner.sh.j2"
      dest: "{{ install_dir }}/{{ packer_template }}.post-provisioner.sh"
 
 - name: Generate Packer Build File
@@ -47,11 +47,28 @@
     src: "packer.{{ packer_os_flavor }}.static.json.j2"
     dest: "{{ install_dir }}/{{ packer_template }}.packer.json"
 
-- name: Generate Template using packer
+- name: Create temporary file
+  delegate_to: localhost
+  tempfile:
+    state: file
+  changed_when: false
+  register: packer_variables
+
+- name: Generate Packer Variables
+  delegate_to: localhost
+  template:
+    src: packer.variables.json.j2
+    dest: "{{ packer_variables.path }}"
+  notify: Delete Packer Variables
+
+- name: Generate Template using Packer - This may take 10/15 mns 
   delegate_to: localhost
   shell: |
-    packer build {{ switch_on_error }} {{ install_dir }}/{{ packer_template }}.packer.json >{{ install_dir }}/{{ packer_template }}.packer.log
+    packer build {{ switch_on_error }} \
+      --var-file={{ packer_variables.path }} \
+      {{ install_dir }}/{{ packer_template }}.packer.json >{{ install_dir }}/{{ packer_template }}.packer.log
   args:
     chdir: "{{ install_dir }}"
   vars:
     switch_on_error: "{% if packer_debug is defined %}--on-error=abort{% else %}{% endif %}"
+

--- a/playbooks/roles/template/templates/centos-post-provisioner.sh.j2
+++ b/playbooks/roles/template/templates/centos-post-provisioner.sh.j2
@@ -14,4 +14,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ### 
-

--- a/playbooks/roles/template/templates/packer.centos.static.json.j2
+++ b/playbooks/roles/template/templates/packer.centos.static.json.j2
@@ -1,11 +1,17 @@
 {
 
+  "_comment": "Copyright (2020) Hewlett Packard Enterprise Development LP", 
+
+  "variables": {
+      "vcenter_password": ""
+  },
+
   "builders": [
     {
       "type": "vsphere-iso",
       "vcenter_server":      "{{ vcenter_hostname }}",
       "username":            "{{ vcenter_username }}",
-      "password":            "{{ vcenter_password }}",
+       "password":            "{{ '{{' }}user `vcenter_password`{{ '}}' }}",
       "insecure_connection": "true",
 
       "datacenter": "{{ datacenter }}",
@@ -50,8 +56,9 @@
     {
       "type": "shell",
       "inline": [
-        "sudo yum install -y cloud-init",
-        "sudo yum install -y cloud-utils-growpart"
+        "sudo install -y cloud-init",
+        "sudo install -y cloud-utils-growpart",
+        "sudo passwd -l root"
       ]
     }
   ]

--- a/playbooks/roles/template/templates/packer.centos.static.json.j2
+++ b/playbooks/roles/template/templates/packer.centos.static.json.j2
@@ -56,8 +56,8 @@
     {
       "type": "shell",
       "inline": [
-        "sudo install -y cloud-init",
-        "sudo install -y cloud-utils-growpart",
+        "sudo yum install -y cloud-init",
+        "sudo yum install -y cloud-utils-growpart",
         "sudo passwd -l root"
       ]
     }

--- a/playbooks/roles/template/templates/packer.ubuntu.static.json.j2
+++ b/playbooks/roles/template/templates/packer.ubuntu.static.json.j2
@@ -1,11 +1,18 @@
 {
+
+  "_comment": "Copyright (2020) Hewlett Packard Enterprise Development LP",
+
+  "variables": {
+      "vcenter_password":  ""
+  },
+
   "builders": [
     {
       "type": "vsphere-iso",
 
       "vcenter_server":      "{{ vcenter_hostname }}",
       "username":            "{{ vcenter_username }}",
-      "password":            "{{ vcenter_password }}",
+      "password":            "{{ '{{' }}user `vcenter_password`{{ '}}' }}",
       "insecure_connection": "true",
       "datacenter": "{{ datacenter }}",
 

--- a/playbooks/roles/template/templates/packer.variables.json.j2
+++ b/playbooks/roles/template/templates/packer.variables.json.j2
@@ -1,0 +1,3 @@
+{
+  "vcenter_password": "{{ vcenter_password }}"
+}

--- a/playbooks/roles/template/templates/preseed.centos.cfg.j2
+++ b/playbooks/roles/template/templates/preseed.centos.cfg.j2
@@ -1,3 +1,18 @@
+###
+# Copyright (2020) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
 install
 cdrom
 lang en_US.UTF-8

--- a/playbooks/roles/template/templates/ubuntu-post-provisioner.sh.j2
+++ b/playbooks/roles/template/templates/ubuntu-post-provisioner.sh.j2
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ### 
-apt-get -y autoremove
 apt-get -y update
 apt-get -y install cloud-init
+apt-get -y autoremove
+
 rm /etc/netplan/*
 cat <<EOF >/etc/netplan/50-cloud-init.yaml
 network:
@@ -26,6 +27,18 @@ network:
     version: 2
 EOF
 
+#
+# clear the machine ID
+#
 : > /etc/machine-id
+
+#
+# lock the password of the account created by the Ubuntu installer
+#
+passwd -l {{ ansible_user }}
+
+#
+# Clear the history
+#
 history -c
 


### PR DESCRIPTION
- store vcenter password in a separate packer file so that it can be deleted after the packer build
- delete the above file even if packer build fails (by mean of a handler)
- add copyright notices in some areas (CentOS preseed/kickstart file) and packer build files
- lock the passwords of the accounts used by packer (root for CentOS, {{ ansible_user }} for Ubuntu when generating the VM template.
