### PR TITLE
fix cloud-init after a reboot

### DIFF
--- a/playbooks/roles/vspherevm/tasks/poweron.yml
+++ b/playbooks/roles/vspherevm/tasks/poweron.yml
@@ -33,15 +33,21 @@
     sleep: 5
     timeout: 300
 
-- name: cloud-init-status
+- name: Disable Cloud-init
   become: true
-  shell: |
-    cloud-init status
-  changed_when: false
-  register: res
-  retries: 20
-  until: |
-    res.stdout == "status: done"
+  file:
+    state: touch
+    path: /etc/cloud/cloud-init.disabled
+
+#- name: cloud-init-status
+#  become: true
+#  shell: |
+#    cloud-init status
+#  changed_when: false
+#  register: res
+#  retries: 20
+#  until: |
+#    res.stdout == "status: done" or 
 
 - name: Attempt to detach the cloud-init CDROM from the VM
   delegate_to: localhost


### PR DESCRIPTION
disable cloud-init after first reboot as the ISO image is now deleted and hence cloud-init won't find it and won't be able to assign the expected IP address to the VM after a reboot