### PR TITLE
Work around Ubuntu netplan bug #1768827

### DIFF
--- a/playbooks/roles/osupdate/tasks/main.yml
+++ b/playbooks/roles/osupdate/tasks/main.yml
@@ -36,3 +36,15 @@
     state: latest
   when: ansible_distribution == "CentOS"
 
+# https://bugs.launchpad.net/netplan/+bug/1768827
+- name: Work around for Ubuntu netplan bug 1768827
+  become: true
+  shell: |
+    set -eux
+    netplan apply
+    cp /run/systemd/network/*.link /etc/systemd/network/
+    update-initramfs -u
+    touch /etc/netplan.fix
+  args:
+    creates: /etc/netplan.fix
+  when: ansible_distribution == "Ubuntu"


### PR DESCRIPTION
workaround to https://bugs.launchpad.net/netplan/+bug/1768827
- network config is not applied after a reboot on  renamed network interfaces (Ubuntu)

